### PR TITLE
Add dev host

### DIFF
--- a/acceptance-tests/Gemfile.lock
+++ b/acceptance-tests/Gemfile.lock
@@ -49,19 +49,6 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rainbow (2.0.0)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.1)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
     rubocop (0.32.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.2.5, < 3.0)
@@ -86,7 +73,6 @@ DEPENDENCIES
   cucumber (= 2.0.0)
   poltergeist (= 1.5.1)
   pry
-  rspec
   rubocop
   test-unit (= 3.1.1)
 

--- a/acceptance-tests/features/support/env.rb
+++ b/acceptance-tests/features/support/env.rb
@@ -4,5 +4,5 @@
 ### need to change every test when switching environments for example.       ###
 ################################################################################
 
-$CHARGES_URL = (ENV['CONVEYANCER_FE_URL'] || 'http://0.0.0.0:9040')
-$CASE_API_URL = (ENV['CASE_API_URL'] || 'http://0.0.0.0:9070')
+$CHARGES_URL = (ENV['CONVEYANCER_FE_URL'] || 'http://conveyancer-frontend.dev.service.gov.uk')
+$CASE_API_URL = (ENV['CASE_API_URL'] || 'http://case-api.dev.service.gov.uk')

--- a/acceptance-tests/features/support/env.rb
+++ b/acceptance-tests/features/support/env.rb
@@ -4,5 +4,7 @@
 ### need to change every test when switching environments for example.       ###
 ################################################################################
 
-$CHARGES_URL = (ENV['CONVEYANCER_FE_URL'] || 'http://conveyancer-frontend.dev.service.gov.uk')
+$CHARGES_URL = (
+  ENV['CONVEYANCER_FE_URL'] || 'http://conveyancer-frontend.dev.service.gov.uk'
+)
 $CASE_API_URL = (ENV['CASE_API_URL'] || 'http://case-api.dev.service.gov.uk')

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,8 @@
 import os
 
 DEBUG = True
-CASE_API_BASE_HOST = os.getenv('CASE_API_BASE_HOST', '')
+CASE_API_BASE_HOST = os.getenv('CASE_API_BASE_HOST',
+                               'http://case-api.dev.service.gov.uk')
 # TODO change this line when we decide to use real CASE API
 # CASE_CLIENT = 'app.service.case_api_client.CaseApiClient'
 CASE_CLIENT = 'tests.mock.case_api_mock_client.CaseApiMockClient'

--- a/puppet/conveyancer_frontend/Puppetfile
+++ b/puppet/conveyancer_frontend/Puppetfile
@@ -1,5 +1,5 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 mod 'LandRegistry/standard_env',
-  :git => 'git://github.com/LandRegistry/standard-env',
-  :ref => 'master'
+    git: 'git://github.com/LandRegistry/standard-env',
+    ref: 'master'

--- a/puppet/conveyancer_frontend/manifests/init.pp
+++ b/puppet/conveyancer_frontend/manifests/init.pp
@@ -8,7 +8,7 @@ class conveyancer_frontend (
     $domain = undef,
     $owner = 'vagrant',
     $group = 'vagrant',
-    $case_api_base_host = 'http://caseapi.lrdigitalmortgage-int.com:20100'
+    $case_api_base_host = 'http://case-api.dev.service.gov.uk'
 ) {
   require ::standard_env
 

--- a/puppet/conveyancer_frontend/manifests/init.pp
+++ b/puppet/conveyancer_frontend/manifests/init.pp
@@ -4,7 +4,8 @@ class conveyancer_frontend (
     $host = '0.0.0.0',
     $branch_or_revision = 'master',
     $source = 'git://github.com/LandRegistry/charges-conveyancer-frontend',
-    $domain = 'conveyancer-frontend.*',
+    $subdomain = 'conveyancer-frontend',
+    $domain = undef,
     $owner = 'vagrant',
     $group = 'vagrant',
     $case_api_base_host = 'http://caseapi.lrdigitalmortgage-int.com:20100'
@@ -68,5 +69,9 @@ class conveyancer_frontend (
       File["/etc/systemd/system/${module_name}.service"],
       File["/var/run/${module_name}"],
     ],
+  }
+
+  if $environment == 'development' {
+    standard_env::dev_host { $subdomain: }
   }
 }

--- a/puppet/conveyancer_frontend/templates/nginx.conf.erb
+++ b/puppet/conveyancer_frontend/templates/nginx.conf.erb
@@ -1,6 +1,10 @@
 server {
   listen 80;
-  server_name <%=@domain%>;
+  <% if @domain %>
+    server_name <%= @domain %>;
+  <% else %>
+    server_name <%= @subdomain %>.*;
+  <% end %>
 
   location / {
     proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
This pull request adds a host entry for the deed api to development deploys of the app and changes the acceptance tests to point to that new host.

The intention is to make the process of developing easier by not having to hoke around for port numbers and IPs.
